### PR TITLE
Update for Django 2.0; Update DB constraints

### DIFF
--- a/bugreports/models.py
+++ b/bugreports/models.py
@@ -8,7 +8,7 @@ class Report(models.Model):
 	body = models.TextField(max_length=8192)
 
 	# currently broken - would need to customise form shit to do this zzz
-	reporter = models.ForeignKey(Member, null=True, blank=True)
+	reporter = models.ForeignKey(Member, null=True, blank=True, on_delete=models.SET_NULL)
 
 	NEEDSREVIEW=None
 	CLOSED=-1

--- a/exec/models.py
+++ b/exec/models.py
@@ -16,5 +16,5 @@ class ExecRole(models.Model):
 	bio = models.TextField(blank=True)
 	bio.help_text = 'Description of the role and what it entails, as well as a short personal bio.'
 
-	incumbent = models.ForeignKey(Member, null=True, blank=True)
+	incumbent = models.ForeignKey(Member, null=True, blank=True, on_delete=models.SET_NULL)
 	incumbent.help_text = 'Member who is currently in this role'

--- a/forum/models.py
+++ b/forum/models.py
@@ -88,7 +88,7 @@ class Thread(models.Model):
 	# cascade because we need to be able to delete forums maybe?
 	# in which case forumless threads will either die,
 	# or need to be moved -before- the forum is deleted
-	forum = models.ForeignKey(Forum, on_delete = models.CASCADE)
+	forum = models.ForeignKey(Forum, on_delete=models.CASCADE)
 
 	title = models.CharField(max_length=64)
 	body = models.CharField(max_length=8192)
@@ -97,8 +97,8 @@ class Thread(models.Model):
 	# pinned/stickied/whatever threads will show up before all others in their forums
 	is_pinned = models.BooleanField(default=False)
 
-	# we should not be "hard" deleting users so
-	author = models.ForeignKey(Member, on_delete=models.PROTECT)
+	# until we implement proper banning/deactivation, just cascade
+	author = models.ForeignKey(Member, on_delete=models.CASCADE)
 
 	def get_response_count(self):
 		return Response.objects.filter(thread=self.id).count()
@@ -120,4 +120,4 @@ class Response(models.Model):
 	body = models.CharField(max_length=8192)
 
 	pub_date = models.DateTimeField('date posted', auto_now_add=True)
-	author = models.ForeignKey(Member, on_delete=models.PROTECT)
+	author = models.ForeignKey(Member, on_delete=models.CASCADE)

--- a/messaging/models.py
+++ b/messaging/models.py
@@ -65,7 +65,7 @@ class MessageThread(models.Model):
 class Message(models.Model):
 	def __str__(self):
 		return str(self.sender) + ': ' + str(self.content)
-	thread = models.ForeignKey(MessageThread)
-	sender = models.ForeignKey(Member)
+	thread = models.ForeignKey(MessageThread, on_delete=models.CASCADE)
+	sender = models.ForeignKey(Member, on_delete=models.CASCADE)
 	content = models.CharField(blank=False, max_length=4096)
 	timestamp = models.DateTimeField(auto_now_add=True)

--- a/rpgs/models.py
+++ b/rpgs/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.safestring import mark_safe, mark_for_escaping
+from django.utils.safestring import mark_safe
 from django.urls import reverse
 
 from users.models import Member
@@ -77,7 +77,7 @@ class Session(models.Model):
 	def __str__(self):
 		date = self.plan_date
 		return self.game.title + ' ' + date.strftime('%d %b')
-	game = models.ForeignKey(Rpg)
+	game = models.ForeignKey(Rpg, on_delete=models.PROTECT)
 
 	# when it's planned to run
 	plan_date = models.DateField()

--- a/rpgs/templatetags/rpg_tags.py
+++ b/rpgs/templatetags/rpg_tags.py
@@ -11,7 +11,7 @@ def can_manage(member, rpg):
 	return (member == rpg.creator) or (member in list(rpg.game_masters.all()))
 
 # todo: assignment tag is deprecated
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def is_player(context, rpg):
 	return rpg.members.filter(id=context.request.user.member.id)
 

--- a/rpgs/views.py
+++ b/rpgs/views.py
@@ -169,7 +169,7 @@ def edit_process(request, pk):
 			newtags.append(Tag.objects.get_or_create(name=tag)[0])"""
 
 		# change tags
-		rpg.tags = tags_from_str(form.data['tags'])
+		rpg.tags.set(tags_from_str(form.data['tags']))
 
 		# cleanup?
 		# remove tags that have no uses

--- a/rpgs/views.py
+++ b/rpgs/views.py
@@ -121,7 +121,7 @@ def create_done(request):
 		newtags.append(Tag.objects.get_or_create(name=tag)[0])"""
 
 	# add tags
-	ins.tags = tags_from_str(request.POST.get('tags', ''))
+	ins.tags.set(tags_from_str(request.POST.get('tags', '')))
 
 	if(request.POST.get('am_i_gm', None)):
 		ins.game_masters.add(me)

--- a/users/models.py
+++ b/users/models.py
@@ -19,7 +19,7 @@ class Member(models.Model):
 
 		return 'https://www.gravatar.com/avatar/{}?{}'.format(h, q)
 
-	equiv_user = models.OneToOneField(User, on_delete=models.PROTECT)
+	equiv_user = models.OneToOneField(User, on_delete=models.CASCADE)
 	def __str__(self):
 		return self.equiv_user.username
 	bio = models.CharField(max_length=4096, blank=True)


### PR DESCRIPTION
- Removed usage of deprecated functionality for compatibility with Django 2.0
- Changed several `ForeignKey` constraints from `on delete protect` to `on delete cascade`.
     - Deleting spam accounts was inconvenient because previously it was necessary to delete all of the account's posts